### PR TITLE
Replace ß with ss instead of b

### DIFF
--- a/linkedin2username.py
+++ b/linkedin2username.py
@@ -133,7 +133,7 @@ def remove_accents(string):
     string = re.sub(u"[òóôõö]", 'o', string)
     string = re.sub(u"[ùúûü]", 'u', string)
     string = re.sub(u"[ýÿ]", 'y', string)
-    string = re.sub(u"[ß]", 'b', string)
+    string = re.sub(u"[ß]", 'ss', string)
     return string
 
 def clean(list):


### PR DESCRIPTION
Hey, thanks for this tool, good stuff! Minor suggestion... the ß symbol in German is usually equivalent to `ss` or `sz`, not `b`.

Will definitely give this a whirl on an engagement! :)