### PR TITLE
Fix company name

### DIFF
--- a/linkedin2username.py
+++ b/linkedin2username.py
@@ -15,7 +15,7 @@ import time
 import argparse
 import getpass
 from distutils.version import StrictVersion
-
+import urllib.parse
 import requests
 
 
@@ -315,10 +315,11 @@ def get_company_info(name, session):
     staff_regex = r'staffCount":([0-9]+),'
     id_regex = r'normalized_company:([0-9]+)[&,"]'
     desc_regex = r'localizedName":"(.*?)"'
+    escaped_name = urllib.parse.quote_plus(name)
 
     response = session.get(('https://www.linkedin.com'
                             '/voyager/api/organization/companies?'
-                            'q=universalName&universalName=' + name))
+                            'q=universalName&universalName=' + escaped_name))
 
     # Some geo regions are being fed a 'lite' version of LinkedIn mobile:
     # https://bit.ly/2vGcft0


### PR DESCRIPTION
You might come across compnies that include reserved characters such as sub-delimiters in their names. Those names need to be URL-encoded when passed as a part of `GET` parameter. For instance, if the target company name is `foo-&-bar-llp` this will result in `400 Bad Request` due to `&` sub-delimiter in `universalName`.

![Capture](https://user-images.githubusercontent.com/17316888/56228900-b90b1800-6046-11e9-888f-083853cca94d.JPG)

The fix will make sure its URL-encoded before passing it to the `GET` http request. Obviously the company name is made up hence the `404 Not Found`

![Capture](https://user-images.githubusercontent.com/17316888/56230512-6af81380-604a-11e9-9457-23db8fd0f392.JPG)

Hopefully the description is good enough. 

Thanks!