### PR TITLE
Running total off by one patch

### DIFF
--- a/linkedin2username.py
+++ b/linkedin2username.py
@@ -551,6 +551,12 @@ def scrape_info(session, company_id, staff_count, args):
             # We parse through them all here, and see which ones are new to us.
             for first, last in zip(first_name, last_name):
                 full_name = first + ' ' + last
+
+		# Off-By-One Running Total Patch: Ensures that a blank first and 
+                # last name are not added to the list of full names.
+                if len(full_name) <= 1:
+                    continue
+
                 if full_name not in full_name_list:
                     full_name_list.append(full_name)
                     new_names += 1

--- a/linkedin2username.py
+++ b/linkedin2username.py
@@ -552,7 +552,7 @@ def scrape_info(session, company_id, staff_count, args):
             for first, last in zip(first_name, last_name):
                 full_name = first + ' ' + last
 
-		# Off-By-One Running Total Patch: Ensures that a blank first and 
+                # Off-By-One Running Total Patch: Ensures that a blank first and 
                 # last name are not added to the list of full names.
                 if len(full_name) <= 1:
                     continue


### PR DESCRIPTION
Running total is always off by one. The code did not account for empty first and last names. The initial empty first and last name string gets added to the full_name list and all others are dropped. This skews the total running count by one.