### PR TITLE
Added cookie functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,42 +33,41 @@ $ python linkedin2username.py myname@email.com uber-com -d 5 -n 'uber.com'
 
 # Full Help
 ```
-usage: linkedin2username.py [-h] [-p PASSWORD] [-n DOMAIN] [-d DEPTH]
-                            [-s SLEEP]
-                            username company
+usage: linkedin2username.py [-h] [-u USERNAME] -c COMPANY [-p PASSWORD] [-n DOMAIN] [-d DEPTH] [-s SLEEP] [-x PROXY]
+                            [-k KEYWORDS] [-f COOKIEFILE] [-g]
 
-positional arguments:
-  username              A valid LinkedIn username.
-  company               Company name.
+OSINT tool to generate lists of probable usernames from a given company's LinkedIn page. This tool may break when LinkedIn
+changes their site. Please open issues on GitHub to report any inconsistencies, and they will be quickly fixed.
 
 optional arguments:
   -h, --help            show this help message and exit
+  -u USERNAME, --username USERNAME
+                        A valid LinkedIn username.
+  -c COMPANY, --company COMPANY
+                        Company name exactly as typed in the company linkedin profile page URL.
   -p PASSWORD, --password PASSWORD
-                        Specify your password on in clear-text on the command
-                        line. If not specified, will prompt and not display on
-                        screen.
+                        Specify your password in clear-text on the command line. If not specified, will prompt and obfuscate as    
+                        you type.
   -n DOMAIN, --domain DOMAIN
-                        Append a domain name to username output. [example: '-n
-                        uber.com' would ouput jschmoe@uber.com]
+                        Append a domain name to username output. [example: "-n uber.com" would output jschmoe@uber.com]
   -d DEPTH, --depth DEPTH
-                        Search depth. If unset, will try to grab them all.
+                        Search depth (how many loops of 25). If unset, will try to grab them all.
   -s SLEEP, --sleep SLEEP
-                        Seconds to sleep between pages. defaults to 3.
+                        Seconds to sleep between search loops. Defaults to 0.
   -x PROXY, --proxy PROXY
-                        HTTPS proxy server to use. Example: "-p
-                        https://localhost:8080" WARNING: WILL DISABLE SSL
-                        VERIFICATION.
-
+                        Proxy server to use. WARNING: WILL DISABLE SSL VERIFICATION. [example: "-p https://localhost:8080"]        
   -k KEYWORDS, --keywords KEYWORDS
-                        Filter results by a a list of command separated
-                        keywords. Will do a separate loop for each keyword,
-                        potentially bypassing the 1,000 record limit.
-                        [example: "-k 'sales,human resources,information
+                        Filter results by a a list of command separated keywords. Will do a separate loop for each keyword,        
+                        potentially bypassing the 1,000 record limit. [example: "-k 'sales,human resources,information
                         technology']
-  -g, --geoblast        Attempts to bypass the 1,000 record search limit by
-                        running multiple searches split across geographic
+  -f COOKIEFILE, --cookiefile COOKIEFILE
+                        Path to a Netscape cookie file to import instead of authenticating with username/password combo.
+  -g, --geoblast        Attempts to bypass the 1,000 record search limit by running multiple searches split across geographic      
                         regions.
 ```
+
+# Scripts
+`convertCookies.py` - Convert a json cookie file to a Netscape cookie file. Helpful to convert a cookie export from a web browser extension such as [cookie-editor](https://github.com/moustachauve/cookie-editor)
 
 # Toubleshooting
 Sometimes LinkedIn does weird stuff or returns weird results. Sometimes it doesn't like you logging in from new locations. If something looks off, run the tool once or twice more. If it still isn't working, please open an issue.

--- a/README.md
+++ b/README.md
@@ -33,36 +33,47 @@ $ python linkedin2username.py myname@email.com uber-com -d 5 -n 'uber.com'
 
 # Full Help
 ```
-usage: linkedin2username.py [-h] [-u USERNAME] -c COMPANY [-p PASSWORD] [-n DOMAIN] [-d DEPTH] [-s SLEEP] [-x PROXY]
-                            [-k KEYWORDS] [-f COOKIEFILE] [-g]
+usage: linkedin2username.py [-h] [-u USERNAME] -c COMPANY [-p PASSWORD] 
+[-n DOMAIN] [-d DEPTH] [-s SLEEP] [-x PROXY] [-k KEYWORDS] [-f COOKIEFILE]
+[-g]
 
-OSINT tool to generate lists of probable usernames from a given company's LinkedIn page. This tool may break when LinkedIn
-changes their site. Please open issues on GitHub to report any inconsistencies, and they will be quickly fixed.
+OSINT tool to generate lists of probable usernames from a given company's
+LinkedIn page. This tool may break when LinkedIn changes their site. Please
+open issues on GitHub to report any inconsistencies, and they will be quickly
+fixed.
 
 optional arguments:
   -h, --help            show this help message and exit
   -u USERNAME, --username USERNAME
                         A valid LinkedIn username.
   -c COMPANY, --company COMPANY
-                        Company name exactly as typed in the company linkedin profile page URL.
+                        Company name exactly as typed in the company linkedin
+                        profile page URL.
   -p PASSWORD, --password PASSWORD
-                        Specify your password in clear-text on the command line. If not specified, will prompt and obfuscate as    
-                        you type.
+                        Specify your password in clear-text on the command
+                        line. If not specified, will prompt and obfuscate as you type.
   -n DOMAIN, --domain DOMAIN
-                        Append a domain name to username output. [example: "-n uber.com" would output jschmoe@uber.com]
+                        Append a domain name to username output. [example: "-n
+                        uber.com" would output jschmoe@uber.com]
   -d DEPTH, --depth DEPTH
-                        Search depth (how many loops of 25). If unset, will try to grab them all.
+                        Search depth (how many loops of 25). If unset, will try
+                        to grab them all.
   -s SLEEP, --sleep SLEEP
                         Seconds to sleep between search loops. Defaults to 0.
   -x PROXY, --proxy PROXY
-                        Proxy server to use. WARNING: WILL DISABLE SSL VERIFICATION. [example: "-p https://localhost:8080"]        
+                        Proxy server to use. WARNING: WILL DISABLE SSL
+                        VERIFICATION. [example: "-p https://localhost:8080"]        
   -k KEYWORDS, --keywords KEYWORDS
-                        Filter results by a a list of command separated keywords. Will do a separate loop for each keyword,        
-                        potentially bypassing the 1,000 record limit. [example: "-k 'sales,human resources,information
-                        technology']
+                        Filter results by a a list of command separated
+                        keywords. Will do a separate loop for each keyword,
+                        potentially bypassing the 1,000 record limit. 
+                        [example: 
+                        "-k 'sales,humanresources,informationtechnology']
   -f COOKIEFILE, --cookiefile COOKIEFILE
-                        Path to a Netscape cookie file to import instead of authenticating with username/password combo.
-  -g, --geoblast        Attempts to bypass the 1,000 record search limit by running multiple searches split across geographic      
+                        Path to a Netscape cookie file to import instead of
+                        authenticating with username/password combo.
+  -g, --geoblast        Attempts to bypass the 1,000 record search limit by
+                        running multiple searches split across geographic
                         regions.
 ```
 

--- a/linkedin2username.py
+++ b/linkedin2username.py
@@ -21,8 +21,7 @@ from http.cookiejar import MozillaCookieJar
 import json
 import datetime
 
-
-                ########## BEGIN GLOBAL DECLARATIONS ##########
+########## BEGIN GLOBAL DECLARATIONS ##########
 
 CURRENT_REL = '0.21'
 BANNER = r"""
@@ -43,23 +42,23 @@ BANNER = r"""
 # search limit as we are now allowed 1000 per geo set.
 # developer.linkedin.com/docs/v1/companies/targeting-company-shares#additionalcodes
 GEO_REGIONS = {
-    'r0':'us:0',
-    'r1':'ca:0',
-    'r2':'gb:0',
-    'r3':'au:0|nz:0',
-    'r4':'cn:0|hk:0',
-    'r5':'jp:0|kr:0|my:0|np:0|ph:0|sg:0|lk:0|tw:0|th:0|vn:0',
-    'r6':'in:0',
-    'r7':'at:0|be:0|bg:0|hr:0|cz:0|dk:0|fi:0',
-    'r8':'fr:0|de:0',
-    'r9':'gr:0|hu:0|ie:0|it:0|lt:0|nl:0|no:0|pl:0|pt:0',
-    'r10':'ro:0|ru:0|rs:0|sk:0|es:0|se:0|ch:0|tr:0|ua:0',
-    'r11':('ar:0|bo:0|br:0|cl:0|co:0|cr:0|do:0|ec:0|gt:0|mx:0|pa:0|pe:0'
-           '|pr:0|tt:0|uy:0|ve:0'),
-    'r12':'af:0|bh:0|il:0|jo:0|kw:0|pk:0|qa:0|sa:0|ae:0'}
+    'r0': 'us:0',
+    'r1': 'ca:0',
+    'r2': 'gb:0',
+    'r3': 'au:0|nz:0',
+    'r4': 'cn:0|hk:0',
+    'r5': 'jp:0|kr:0|my:0|np:0|ph:0|sg:0|lk:0|tw:0|th:0|vn:0',
+    'r6': 'in:0',
+    'r7': 'at:0|be:0|bg:0|hr:0|cz:0|dk:0|fi:0',
+    'r8': 'fr:0|de:0',
+    'r9': 'gr:0|hu:0|ie:0|it:0|lt:0|nl:0|no:0|pl:0|pt:0',
+    'r10': 'ro:0|ru:0|rs:0|sk:0|es:0|se:0|ch:0|tr:0|ua:0',
+    'r11': ('ar:0|bo:0|br:0|cl:0|co:0|cr:0|do:0|ec:0|gt:0|mx:0|pa:0|pe:0'
+            '|pr:0|tt:0|uy:0|ve:0'),
+    'r12': 'af:0|bh:0|il:0|jo:0|kw:0|pk:0|qa:0|sa:0|ae:0'}
 
 NETSCAPE_COOKIEJAR = "cookies_netscape.txt"
-                 ########## END GLOBAL DECLARATIONS ##########
+########## END GLOBAL DECLARATIONS ##########
 
 
 if sys.version_info < (3, 0):
@@ -130,12 +129,11 @@ def parse_arguments():
                         help='Attempts to bypass the 1,000 record search limit'
                         ' by running multiple searches split across geographic'
                         ' regions.')
-    
 
     args = parser.parse_args()
 
     # Proxy argument is fed to requests as a dictionary, setting this now:
-    args.proxy_dict = {"https" : args.proxy}
+    args.proxy_dict = {"https": args.proxy}
 
     # If appending an email address, preparing this string now:
     if args.domain:
@@ -159,7 +157,7 @@ def parse_arguments():
     # If we get a cookiefile then we can just continue without the password
     if args.cookiefile != None:
         return args
-    
+
     # If password is not passed in the command line, prompt for it
     # in a more secure fashion (not shown on screen)
     args.password = args.password or getpass.getpass()
@@ -210,12 +208,13 @@ def check_li2u_version():
               .format(CURRENT_REL, latest_rel))
         return
 
+
 def parseCookieFile(cookiefile):
     """Parse a Netscape cookies file and return a dictionary of key value pairs
     compatible with requests."""
 
     cookies = []
-    with open (cookiefile, 'r') as fp:
+    with open(cookiefile, 'r') as fp:
         for line in fp:
             if not re.match(r'^\#', line):
                 lineFields = line.strip().split('\t')
@@ -225,6 +224,7 @@ def parseCookieFile(cookiefile):
                 subCookie["value"] = lineFields[6]
                 cookies.append(subCookie)
     return cookies
+
 
 def login(args):
     """Creates a new authenticated session.
@@ -250,13 +250,15 @@ def login(args):
             try:
                 cookies = parseCookieFile(args.cookiefile)
             except Exception as e:
-                print("Failed to parse the cookie file: {0}".format(args.cookiefile))
+                print("Failed to parse the cookie file: {0}".format(
+                    args.cookiefile))
                 print(str(e))
                 sys.exit(1)
 
             # Add cookies to our session object
             for cookie in cookies:
-                cookie_obj = requests.cookies.create_cookie(domain=cookie["domain"],name=cookie["key"],value=cookie["value"])
+                cookie_obj = requests.cookies.create_cookie(
+                    domain=cookie["domain"], name=cookie["key"], value=cookie["value"])
                 session.cookies.set_cookie(cookie_obj)
 
             return session
@@ -298,7 +300,7 @@ def login(args):
         'session_password': args.password,
         'isJsEnabled': 'false',
         'loginCsrfParam': login_csrf
-        }
+    }
 
     # Perform the actual login. We disable redirects as we will use that 302
     # as an indicator of a successful logon.
@@ -434,7 +436,7 @@ def get_company_info(name, session):
     print("\n" + PC.ok_box + "Hopefully that's the right {}! If not, "
           "double-check LinkedIn and try again.\n".format(name))
 
-    return(found_id[0], int(found_staff[0]))
+    return (found_id[0], int(found_staff[0]))
 
 
 def set_loops(staff_count, args):
@@ -500,7 +502,7 @@ def get_results(session, company_id, page, region, keyword):
     # When using the --geoblast feature, we need to inject our set of region
     # codes into the search parameter.
     if region:
-        region = re.sub(':', '%3A', region) # must URL encode this parameter
+        region = re.sub(':', '%3A', region)  # must URL encode this parameter
 
     # Build the base search URL.
     url = ('https://www.linkedin.com'
@@ -571,7 +573,7 @@ def scrape_info(session, company_id, staff_count, args):
             current_region = ''
             current_keyword = ''
 
-        ## This is the inner loop. It will search results 25 at a time.
+        # This is the inner loop. It will search results 25 at a time.
         for page in range(0, args.depth):
             new_names = 0
             sys.stdout.flush()
@@ -604,7 +606,7 @@ def scrape_info(session, company_id, staff_count, args):
             for first, last in zip(first_name, last_name):
                 full_name = first + ' ' + last
 
-                # Off-By-One Running Total Patch: Ensures that a blank first and 
+                # Off-By-One Running Total Patch: Ensures that a blank first and
                 # last name are not added to the list of full names.
                 if len(full_name) <= 1:
                     continue
@@ -613,7 +615,7 @@ def scrape_info(session, company_id, staff_count, args):
                     full_name_list.append(full_name)
                     new_names += 1
             sys.stdout.write("    " + PC.ok_box + "Added " + str(new_names) +
-                             " new names. Running total: "\
+                             " new names. Running total: "
                              + str(len(full_name_list)) + "              \r")
 
             # If the user has defined a sleep between loops, we take a little
@@ -656,7 +658,7 @@ def clean(raw_list):
 
         # Lower-case everything to make it easier to de-duplicate.
         name = name.lower()
-      
+
         # Try to transform non-English characters below.
         name = remove_accents(name)
 

--- a/scripts/convertCookies.py
+++ b/scripts/convertCookies.py
@@ -1,0 +1,76 @@
+from datetime import timedelta
+import json
+import datetime
+import argparse
+import sys
+from os.path import exists
+
+# parse_arguments: Handle user-supplied arguments
+def parse_arguments():
+
+    desc = ('Format a json file into a Netscape cookie file')
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument('-c', '--cookiefile', type=str, action="store", 
+                        default=False, required=True,
+                        help='Path to a json cookie file to convert to a netscape file')
+    parser.add_argument('-o', '--outfile', type=str, action="store", 
+                        default="cookies_netscape.txt",
+                        help='Path to an output file')
+
+    args = parser.parse_args()
+
+    if args.cookiefile == "":
+        print("ERROR: Missing argument -c,--cookiefile ")
+        parser.print_usage()
+        sys.exit(1)
+    
+    return args
+
+# json2NetscapeFile: Convert a json cookie file to netscape
+def json2NetscapeFile(inFile, outFile):
+    cookiecounter = 1
+    if not exists(inFile):
+        print("ERROR: file '{0}' does not exist".format(inFile))
+        sys.exit(1)
+    with open(outFile, "w") as cookie_handle:
+        
+        # Write netscape header
+        cookie_handle.write("# Netscape HTTP Cookie File\n")
+
+        # Open and read json file
+        handle_cookies = open(inFile)
+        obj_cookies = json.load(handle_cookies)
+        handle_cookies.close()
+
+        # Loop json dictionary and create netscape cookie string
+        
+        for cookie in obj_cookies:
+            
+            netscape_cookie = "{domain}\t{domain_notnull}\t{path}\t{secure}\t{expiration}\t{c_name}\t{c_value}".format(
+                domain=cookie["domain"],
+                domain_notnull=("TRUE" if cookie["domain"].startswith(".") else "FALSE"),
+                path=cookie["path"],secure=cookie["secure"],
+                expiration=(cookie["expirationDate"] if "expirationDate" in cookie.keys() and cookie["expirationDate"] != "" else (datetime.datetime.now()+timedelta(days=1)).timestamp()),
+                c_name=cookie["name"],
+                c_value=cookie["value"]
+                )
+            
+            # Write netscape cookie string to file
+            cookie_handle.write(netscape_cookie+"\n")
+            cookiecounter += 1
+    
+    print("Parsed cookies: {0} ".format(cookiecounter))
+    # Print arr_cookies
+    #[print(cookie) for cookie in arr_cookies]
+
+def main():
+    # Parse arguments
+    args = parse_arguments()
+    
+    # Convert cookie json to netscape
+    json2NetscapeFile(args.cookiefile, args.outfile)
+
+    print("Output file: {0}".format(args.outfile))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Problem
I was having a weird problem with LinkedIn where every time I logged out and logged back in I would get a pop-up asking me to confirm my email and phone number. This obliviously created a problem for using this tool, as after successfully authenticating to LinkedIn, I would not be redirected to '/feed' but to the pop-up which causes the script to exit.

### Solution
This pull request adds the ability use a Netscape formatted cookie file with the tool, instead of having the tool authenticate with a username/password combo. It also adds a `scripts` folder with a python script to convert a json python dictionary to the needed Netscape cookie file format.