### PR TITLE
Add ability to skip phone prompt

### DIFF
--- a/linkedin2username.py
+++ b/linkedin2username.py
@@ -229,10 +229,12 @@ def login(args):
                   " in with your web browser first and come back later.")
             return False
         if 'add-phone' in redirect:
-            print(PC.warn_box + "LinkedIn is prompting to add your phone"
-                  " number to your profile. Please handle that in the web and"
-                  " then try again.")
-            return False
+            # Skip the prompt to add a phone number
+            response = session.post('https://www.linkedin.com/checkpoint/post-login/security/dismiss-phone-event')
+            if response.status_code != 200:
+                print(PC.warn_box + "Could not skip phone prompt. Please log in via the web app first and then try again.\n")
+                return False
+            return True
         if 'manage-account' in redirect:
             print(PC.warn_box + "LinkedIn has some account notification for you"
                   " to check. Please log in first via the web and clear that.")


### PR DESCRIPTION
Previously, the tool would exit if prompted to add a number. However, it should be possible to skip it using this.

I was able to capture the requests required to skip the phone prompt. However, now I am not being prompted again so I cannot actually verify this fix works.

It would be great if someone who encounters the error could test this branch.

Otherwise, I will try again maybe in a few weeks.