### PR TITLE
Fix 403 error

### DIFF
--- a/linkedin2username.py
+++ b/linkedin2username.py
@@ -291,7 +291,8 @@ def login(args):
                     'Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) '
                     'Version/4.0 Mobile Safari/534.30')
     session.headers.update({'User-Agent': mobile_agent,
-                            'X-RestLi-Protocol-Version': '2.0.0'})
+                            'X-RestLi-Protocol-Version': '2.0.0',
+                            'X-Li-Track': '{"clientVersion":"1.13.1665"}'})
 
     # We wll grab an anonymous response to look for the CSRF token, which
     # is required for our logon attempt.


### PR DESCRIPTION
This is a new required header for the voyager API.

It fixes some 403 errors that completely broke the tool.