### PR TITLE
Handle missing key/value pairs better

### DIFF
--- a/linkedin2username.py
+++ b/linkedin2username.py
@@ -499,20 +499,20 @@ def find_employees(result):
     # The "elements" list is the mini-profile you see when scrolling through a
     # company's employees. It does not have all info on the person, like their
     # entire job history. It only has some basics.
-found_employees = []
-for body in result_json.get('elements', []):
-    profile = (
-        body.get('hitInfo', {})
-        .get('com.linkedin.voyager.search.SearchProfile', {})
-        .get('miniProfile', {})
-    )
-    first_name = profile.get('firstName', '').strip()
-    last_name = profile.get('lastName', '').strip()
+    found_employees = []
+    for body in result_json.get('elements', []):
+        profile = (
+            body.get('hitInfo', {})
+            .get('com.linkedin.voyager.search.SearchProfile', {})
+            .get('miniProfile', {})
+        )
+        first_name = profile.get('firstName', '').strip()
+        last_name = profile.get('lastName', '').strip()
 
-    # Dont include profiles that have only a single name
-    if first_name and last_name:
-        full_name = f"{first_name} {last_name}"
-        occupation = profile.get('occupation', "")
+        # Dont include profiles that have only a single name
+        if first_name and last_name:
+            full_name = f"{first_name} {last_name}"
+            occupation = profile.get('occupation', "")
 
     return found_employees
 

--- a/linkedin2username.py
+++ b/linkedin2username.py
@@ -499,19 +499,21 @@ def find_employees(result):
     # The "elements" list is the mini-profile you see when scrolling through a
     # company's employees. It does not have all info on the person, like their
     # entire job history. It only has some basics.
-    for body in result_json['elements']:
-        profile = (body['hitInfo']
-                       ['com.linkedin.voyager.search.SearchProfile']
-                       ['miniProfile'])
-        full_name = f"{profile['firstName']} {profile['lastName']}"
-        employee = {'full_name': full_name,
-                    'occupation': profile['occupation']}
+    found_employees = []
+    for body in result_json.get('elements', []):
+        profile = (
+            body.get('hitInfo', {})
+            .get('com.linkedin.voyager.search.SearchProfile', {})
+            .get('miniProfile', {})
+        )
+        full_name = f"{profile.get('firstName', '')} {profile.get('lastName', '')}".strip()
+        occupation = profile.get('occupation', "")
 
-        # Some employee names are not disclosed and return empty. We don't want those.
-        if len(employee['full_name']) > 1:
-            found_employees.append(employee)
+        if full_name:
+            found_employees.append({'full_name': full_name, 'occupation': occupation})
 
     return found_employees
+
 
 
 def do_loops(session, company_id, outer_loops, args):

--- a/linkedin2username.py
+++ b/linkedin2username.py
@@ -509,10 +509,11 @@ def find_employees(result):
         full_name = f"{profile.get('firstName', '')} {profile.get('lastName', '')}".strip()
         occupation = profile.get('occupation', "")
 
-        if full_name:
+        if len(full_name) > 1:
             found_employees.append({'full_name': full_name, 'occupation': occupation})
 
     return found_employees
+
 
 
 

--- a/linkedin2username.py
+++ b/linkedin2username.py
@@ -513,6 +513,7 @@ def find_employees(result):
         if first_name and last_name:
             full_name = f"{first_name} {last_name}"
             occupation = profile.get('occupation', "")
+            found_employees.append({'full_name': full_name, 'occupation': occupation})
 
     return found_employees
 

--- a/linkedin2username.py
+++ b/linkedin2username.py
@@ -514,7 +514,7 @@ for body in result_json.get('elements', []):
         full_name = f"{first_name} {last_name}"
         occupation = profile.get('occupation', "")
 
-return found_employees
+    return found_employees
 
 
 

--- a/linkedin2username.py
+++ b/linkedin2username.py
@@ -499,20 +499,22 @@ def find_employees(result):
     # The "elements" list is the mini-profile you see when scrolling through a
     # company's employees. It does not have all info on the person, like their
     # entire job history. It only has some basics.
-    found_employees = []
-    for body in result_json.get('elements', []):
-        profile = (
-            body.get('hitInfo', {})
-            .get('com.linkedin.voyager.search.SearchProfile', {})
-            .get('miniProfile', {})
-        )
-        full_name = f"{profile.get('firstName', '')} {profile.get('lastName', '')}".strip()
+found_employees = []
+for body in result_json.get('elements', []):
+    profile = (
+        body.get('hitInfo', {})
+        .get('com.linkedin.voyager.search.SearchProfile', {})
+        .get('miniProfile', {})
+    )
+    first_name = profile.get('firstName', '').strip()
+    last_name = profile.get('lastName', '').strip()
+
+    # Dont include profiles that have only a single name
+    if first_name and last_name:
+        full_name = f"{first_name} {last_name}"
         occupation = profile.get('occupation', "")
 
-        if len(full_name) > 1:
-            found_employees.append({'full_name': full_name, 'occupation': occupation})
-
-    return found_employees
+return found_employees
 
 
 

--- a/tests/test_linkedin2username.py
+++ b/tests/test_linkedin2username.py
@@ -8,6 +8,7 @@ TEST_NAMES = {
     2: "John Davidson-Smith",
     3: "John-Paul Smith-Robinson",
     4: "José Gonzáles",
+    5: "🙂 Emoji Folks 🙂"
 }
 
 
@@ -28,6 +29,10 @@ def test_f_last():
     mutator = NameMutator(name)
     assert mutator.f_last() == set(["jgonzales", ])
 
+    name = TEST_NAMES[5]
+    mutator = NameMutator(name)
+    assert mutator.f_last() == set(["efolks", ])
+
 
 def test_f_dot_last():
     name = TEST_NAMES[1]
@@ -45,6 +50,10 @@ def test_f_dot_last():
     name = TEST_NAMES[4]
     mutator = NameMutator(name)
     assert mutator.f_dot_last() == set(["j.gonzales", ])
+
+    name = TEST_NAMES[5]
+    mutator = NameMutator(name)
+    assert mutator.f_dot_last() == set(["e.folks", ])
 
 
 def test_last_f():
@@ -64,6 +73,10 @@ def test_last_f():
     mutator = NameMutator(name)
     assert mutator.last_f() == set(["gonzalesj", ])
 
+    name = TEST_NAMES[5]
+    mutator = NameMutator(name)
+    assert mutator.last_f() == set(["folkse", ])
+
 
 def test_first_dot_last():
     name = TEST_NAMES[1]
@@ -81,6 +94,10 @@ def test_first_dot_last():
     name = TEST_NAMES[4]
     mutator = NameMutator(name)
     assert mutator.first_dot_last() == set(["jose.gonzales", ])
+
+    name = TEST_NAMES[5]
+    mutator = NameMutator(name)
+    assert mutator.first_dot_last() == set(["emoji.folks", ])
 
 
 def test_first_l():
@@ -100,6 +117,10 @@ def test_first_l():
     mutator = NameMutator(name)
     assert mutator.first_l() == set(["joseg", ])
 
+    name = TEST_NAMES[5]
+    mutator = NameMutator(name)
+    assert mutator.first_l() == set(["emojif", ])
+
 
 def test_first():
     name = TEST_NAMES[1]
@@ -117,6 +138,10 @@ def test_first():
     name = TEST_NAMES[4]
     mutator = NameMutator(name)
     assert mutator.first() == set(["jose", ])
+
+    name = TEST_NAMES[5]
+    mutator = NameMutator(name)
+    assert mutator.first() == set(["emoji", ])
 
 
 def test_clean_name():


### PR DESCRIPTION
This MR uses a safer method to extract KV pairs from JSON. Missing pairs should now return empty strings instead of KeyErrors. This should fix https://github.com/initstring/linkedin2username/issues/69